### PR TITLE
Add GitHub Actions workflows

### DIFF
--- a/.github/workflows/analyze_project.yaml
+++ b/.github/workflows/analyze_project.yaml
@@ -1,0 +1,29 @@
+name: Dart Analyzer
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '12.x'
+
+    - name: Install Flutter
+      uses: subosito/flutter-action@v1
+      with:
+        flutter-version: '2.x'
+
+    - name: Get dependencies
+      run: flutter pub get
+
+    - name: Analyze
+      run: flutter analyze

--- a/.github/workflows/calculate_pub_dev_score.yaml
+++ b/.github/workflows/calculate_pub_dev_score.yaml
@@ -1,0 +1,35 @@
+name: PubDev Score
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  package-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: axel-op/dart-package-analyzer@v3
+        id: analysis
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      # use this id to retrieve the outputs in the next steps
+      # exit dirty when the package doesn't reach 100%
+      - name: Check scores
+        env:
+          # "analysis" is the id set above
+          # PERCENTAGE=$(( $TOTAL * 100 / $TOTAL_MAX ))
+          TOTAL: ${{ steps.analysis.outputs.total }}
+          TOTAL_MAX: ${{ steps.analysis.outputs.total_max }}
+          JSON_OUT: ${{ steps.analysis.outputs.json_output }}
+        run: |
+          if (( $TOTAL != $TOTAL_MAX ))
+          then
+            echo There are missing points in the project!
+            echo $TOTAL from $TOTAL_MAX Points reached
+            echo $JSON_OUT | jq
+            exit 1
+          fi


### PR DESCRIPTION
This PR adds two workflows:
- Dart Analyzer: runs `flutter analyze`
- PubDev Score calculation: uses [this](https://github.com/axel-op/dart-package-analyzer) action that uses pana to calculate the scoring on pub.dev of the package (same as pub.dev uses internally, like here described: https://pub.dev/help/scoring)

i.m.h.o. this could help to ensure the quality of the package