### PR TITLE
Update README.md - beta requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,8 @@ PRs are welcome but please create a placeholder PR to discuss before writing any
 
 ## Getting Started
 
-This package requires Flutter >= `3.16.0-0.2.pre`, so you will need to first switch to the `beta` channel: 
+This package requires Flutter >= `3.16.0`.
 
-```
-flutter channel beta
-flutter upgrade
-```
 There are specific issues with earlier versions on Windows/MacOS (mobile should actually be fine, so if you want to experiment on your own you're free to remove the minimum version from `pubspec.yaml`).
 
 Next, clone this repository and pull the latest binaries from Git LFS:


### PR DESCRIPTION
Removed portion where it said needs to be on `beta` channel for `3.16.0-0.2.pre` since stable is on 3.19