### PR TITLE
Download and unzip native assets during build

### DIFF
--- a/dart_filament/native/lib/android/release/arm64-v8a/libbackend.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libbackend.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1aff0246d845db4cc4044de3d4f9ff7773ef4f672d621cef66863414f4de411c
-size 1791046

--- a/dart_filament/native/lib/android/release/arm64-v8a/libbasis_transcoder.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libbasis_transcoder.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:763214f288347f7ad78398e18c17b1898871493b4538361d974fb49a9466cb95
-size 377548

--- a/dart_filament/native/lib/android/release/arm64-v8a/libbluevk.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libbluevk.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7019b736298f3fdae6c561f8cee07fb84055d28dfd69d52d4812968b24794d5d
-size 199928

--- a/dart_filament/native/lib/android/release/arm64-v8a/libcamutils.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libcamutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:69101e5d4ab838035c19f9dfe8c0e33a0c337abbf495f57a8422c3c3da42dd28
-size 43940

--- a/dart_filament/native/lib/android/release/arm64-v8a/libcivetweb.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libcivetweb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:229b158f27cdb7400cf8ada9ff3ace6bb03f7ad523b5079ad05c54485de57bfc
-size 285712

--- a/dart_filament/native/lib/android/release/arm64-v8a/libdracodec.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libdracodec.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5773aae825e71ed29c38a9fc2a2332a6bd69dedba25cb632eaabfafd350b1017
-size 1939142

--- a/dart_filament/native/lib/android/release/arm64-v8a/libfilabridge.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libfilabridge.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df0c3ed7202868b446e12c3f682e4606df9c73270f34835f871651eac405e99b
-size 47462

--- a/dart_filament/native/lib/android/release/arm64-v8a/libfilaflat.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libfilaflat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:996ee83853bd5eeaffd0bc77fc942ee0611ec6dd3c4fdaf5e32192d3b4345cda
-size 32306

--- a/dart_filament/native/lib/android/release/arm64-v8a/libfilamat.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libfilamat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2690bf4bddc6dddcd4d67be17b950a5fd0cdfb2b3d0b1b16732912a3ace59a91
-size 24966462

--- a/dart_filament/native/lib/android/release/arm64-v8a/libfilament-iblprefilter.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libfilament-iblprefilter.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f84deda777d3c82156ce2815ae1f8f4aa939a404577fa59571e2994c9154b02e
-size 65546

--- a/dart_filament/native/lib/android/release/arm64-v8a/libfilament.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libfilament.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39ff3efdab81fc2f81a5b4fc79a700e6ce28d291fe8f339661091c910cd9d51b
-size 2384606

--- a/dart_filament/native/lib/android/release/arm64-v8a/libfilameshio.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libfilameshio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:241eb7ee601094049d3858e209de46f775f8c07cfa9484e0350e779227294061
-size 30970

--- a/dart_filament/native/lib/android/release/arm64-v8a/libgeometry.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libgeometry.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6a0d47aae41fe5054edb14dc9a290a1ef6442abc52ff27e8fb3e088bc99f9a6
-size 296144

--- a/dart_filament/native/lib/android/release/arm64-v8a/libgltfio_core.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libgltfio_core.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0cfed8be42c73be500a8a80403b2ba299fd941a241705ad71c7fd9a9d79f3502
-size 854930

--- a/dart_filament/native/lib/android/release/arm64-v8a/libibl-lite.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libibl-lite.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1ac131a38a487eb0f81bb79b54db1d8e22b81e20f32fee71084748ff7d5db76
-size 199008

--- a/dart_filament/native/lib/android/release/arm64-v8a/libibl.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libibl.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:16ad21995b382f288f1aa019b6b1e543453e8f03f30215f62bfe8c2c3ee6747b
-size 244010

--- a/dart_filament/native/lib/android/release/arm64-v8a/libimage.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libimage.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8c0675caa599e8bd9d2b7a69d7b734b015b2d5aef065838438a84d00c771686
-size 75120

--- a/dart_filament/native/lib/android/release/arm64-v8a/libimageio.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libimageio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2affa1a46f0509e26741e613278ba7742e73d5665b201d9819c9357b3824c9ff
-size 212054

--- a/dart_filament/native/lib/android/release/arm64-v8a/libktxreader.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libktxreader.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6b513ebd8fb5c8465493d965ae371eb35db4accf8ba8b3c72c8b6e669df5a7a
-size 42172

--- a/dart_filament/native/lib/android/release/arm64-v8a/libmeshoptimizer.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libmeshoptimizer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ddb2ec4f6be24a410df7353ca385bf5bff32b5f921d773847735185f38d431e1
-size 112938

--- a/dart_filament/native/lib/android/release/arm64-v8a/libmikktspace.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libmikktspace.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:54d6c7f89cdc0633ca59b78902afe734cde0a1912295fa64d4b24a4b837f0f36
-size 21510

--- a/dart_filament/native/lib/android/release/arm64-v8a/libpng.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libpng.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dde94c36b283091a5a3211e8a336f3f50dd1664db09929e5f2a654adaf0db6b3
-size 355194

--- a/dart_filament/native/lib/android/release/arm64-v8a/libshaders.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b012f9dd0d73ca1f25368f3d076971684d65f2e00f219c8fe3e49964fba672a
-size 132022

--- a/dart_filament/native/lib/android/release/arm64-v8a/libsmol-v.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libsmol-v.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c95c04fddaf2502e4fd18f92fa10dd7b115c95a04b83084d57ac7897bb555f35
-size 45228

--- a/dart_filament/native/lib/android/release/arm64-v8a/libstb.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libstb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4c6073933e1ca709af9d6fbb4b99b825d5de5f424f03d25ea9beacd6cd52e62
-size 125910

--- a/dart_filament/native/lib/android/release/arm64-v8a/libtinyexr.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libtinyexr.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f27ccb09daed406bd49c8d47b1738815d8daf0336a3fea6fdb059876e2416493
-size 226376

--- a/dart_filament/native/lib/android/release/arm64-v8a/libuberarchive.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libuberarchive.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bdd796813716511ca08d0f8815da25c8258e4c85dea67ee6e29417e72a0c374b
-size 1928556

--- a/dart_filament/native/lib/android/release/arm64-v8a/libuberzlib.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libuberzlib.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81b357e83fce4a38612994f161475c7dc5a3dfc81eefc0d55ce3251fde60b3c2
-size 23616

--- a/dart_filament/native/lib/android/release/arm64-v8a/libutils.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71161c4170267552421969d74db8179b6584436dc9fbd5097c1d3e4bbee3d075
-size 247160

--- a/dart_filament/native/lib/android/release/arm64-v8a/libviewer.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libviewer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:48b9096489e6b26284727e9abc8f5b1b969c35dad3e1c452230b0a0cb8832bc9
-size 481530

--- a/dart_filament/native/lib/android/release/arm64-v8a/libvkshaders.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libvkshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5b4a0ed465043699bbcca25fda0c12310f8d29df7a00897fe3617671b3cd6f8
-size 2478

--- a/dart_filament/native/lib/android/release/arm64-v8a/libzstd.a
+++ b/dart_filament/native/lib/android/release/arm64-v8a/libzstd.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8e183e689f3a390bb390a2f7289aeb969ec2087655e163fc86f49c78bd851d4
-size 702122

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libbackend.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libbackend.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6558a579a3a695b2059779b1021ef0b33d4ea20c8b0ae3d151b3a95435508ff
-size 1653800

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libbasis_transcoder.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libbasis_transcoder.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:615e01cf41a25664152543b4a9682037bd23c5b7833e8fbd144d2e84e2f435b2
-size 331162

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libbluevk.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libbluevk.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94b38df30730cfd238548d17f1f333a33d2cdff99a78db0116b0fc99c07bc5b5
-size 97748

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libcamutils.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libcamutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:afce523da2407c5c28dd4b6f84b35b55cbeb54300205f04f01ce3b7b2c733956
-size 47048

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libcivetweb.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libcivetweb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13c14e7d1ea19a535db271e7e407269ebeb75416d2f0fa724611d4999781ab5d
-size 187280

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libdracodec.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libdracodec.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4b8a71b45ba72fa36a462fc0f33025f98f9b29d922383831501699a103df3fb
-size 1790762

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libfilabridge.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libfilabridge.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e86fcce39bc84c5cb3be46fd53b4a2641210dbdeb24889d18fd120f779622497
-size 44308

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libfilaflat.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libfilaflat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57f936061b5be9cfd4cc3cec233888c32432f16bbec3c26a8bd81dcf19e03030
-size 32722

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libfilamat.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libfilamat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f496b49349dacf7be4ed10ae9299e80ad6fcb5839daf7e1f7f152998a946bba1
-size 21918644

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libfilament-iblprefilter.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libfilament-iblprefilter.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab9e805accc8ae3aa9c955c7f42d85cf13d1c111d63ceff53d2a836cf7539e53
-size 57426

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libfilament.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libfilament.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d4585f68d6f5410f5ee0f5f45bde2d8b35ceb4bfc4b9826649e3c2b276c70ab
-size 2469324

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libfilameshio.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libfilameshio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0bbd105d7bc3131a217ae389bc4864bbcf0f3351a09614f2a70479291890a390
-size 29554

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libgeometry.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libgeometry.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d264390f6d658fe406ff1d7b83c80e1ddafd2eead6cc1c491499e9d197846efc
-size 256556

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libgltfio_core.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libgltfio_core.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:38507266bdda058e04a50c63ee567ad15d95fd28b8e8e8499502c81874eee98f
-size 772456

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libibl-lite.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libibl-lite.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c98003c33fd7b27a22469e1fd56a740844f50d89f055be552458f06ccdb0d9c7
-size 208880

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libibl.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libibl.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53bc579c93572ac578223ae3b480c5b2050f7ad5db4ddccf241db46b73362966
-size 258494

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libimage.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libimage.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b43b73ad1f97929c37324b7e3c0c17002368a8fe18b617ee322588941b189314
-size 62584

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libimageio.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libimageio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c413e680c5df5f8ca0600df1938c0c94e52ba15f733fb86dac6259efe8becd1
-size 161038

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libktxreader.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libktxreader.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a623ffc8235e4026b870ea5d9ffc7218e74d081396fd524d95695529d3f26de
-size 35226

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libmeshoptimizer.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libmeshoptimizer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fea1fe71efe236e4ef76e919f2c80a437f6c45c954e47e0abfec3bc4a56ccb4
-size 90442

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libmikktspace.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libmikktspace.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1efc3b24d2f826dfab40094f838b589dde31e59d81ab23e912780465a6403b70
-size 15614

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libpng.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libpng.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd5bf07a67fbb6096da10f6ffc3a60aaf720662370c6ccbbf3582999d0833c28
-size 243322

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libshaders.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:baa0f1dd061111e88f95f807d3e559a690347d97b51052f230208b35d38e4f37
-size 131258

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libsmol-v.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libsmol-v.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ecb96e12638e1ec9b2ad85199c2c6ff4ef0154f4048537a56b7fec7178c4d287
-size 32808

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libstb.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libstb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76c5dfd97d82fb29af80b97077e54f4390a7fc089fcb63e5fd4f236f081c2b3a
-size 86666

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libtinyexr.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libtinyexr.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:09ee485f222900bc3f67d9daec7711d7ca1c57abcacc7f4df5e5f76f2534ea47
-size 152200

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libuberarchive.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libuberarchive.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0bf38d13f6d50e0156d9e448ab914a14a44c469eb1ef32ab11ac32f6234ca99
-size 1928372

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libuberzlib.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libuberzlib.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1aca21da2c95eb45d8b86309d8c4247567477a4bc41d17837df6746ba5204ca5
-size 21136

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libutils.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3fb4bf0d2042f22e51bbb1a1c19c6ea1c74fba2ee8559a135dd0f59a2e8caa20
-size 230088

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libviewer.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libviewer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5320d16ec6fe4cbea461451dc3b2bee631b515b2f975f9c9c1e2e161e14e8d1
-size 362738

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libvkshaders.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libvkshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65a78471c67f042392f860feaa3fd344c436283045191e7666a68ccf7bd3ca7e
-size 2282

--- a/dart_filament/native/lib/android/release/armeabi-v7a/libzstd.a
+++ b/dart_filament/native/lib/android/release/armeabi-v7a/libzstd.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e3a1ded524f9f43884d0fd684574ef0aee22ff888a7985b19d709f4575081ead
-size 564374

--- a/dart_filament/native/lib/android/release/x86/libbackend.a
+++ b/dart_filament/native/lib/android/release/x86/libbackend.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2cb5d81544b7207efa136273c44e3cacb5ae6c2d603f2a34c08640dd3197e824
-size 1516428

--- a/dart_filament/native/lib/android/release/x86/libbasis_transcoder.a
+++ b/dart_filament/native/lib/android/release/x86/libbasis_transcoder.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02253f2e4c8b3a2aa7c9baaae64411dbf8960224424ed35e437b5d14083212ed
-size 380576

--- a/dart_filament/native/lib/android/release/x86/libbluevk.a
+++ b/dart_filament/native/lib/android/release/x86/libbluevk.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a6a15b96e26180ac9f156c1da780e348617fb7831cf8e43d65b85fa4af3e91b
-size 130672

--- a/dart_filament/native/lib/android/release/x86/libcamutils.a
+++ b/dart_filament/native/lib/android/release/x86/libcamutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:572987837608fefb8e66305c70d9a9ad40b146a2bae098c3d3b78c88977c7771
-size 43076

--- a/dart_filament/native/lib/android/release/x86/libcivetweb.a
+++ b/dart_filament/native/lib/android/release/x86/libcivetweb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe4fc867f32291cb35cac5bc2970b79b266d9f701408b81f6cf288cd8afbece9
-size 231264

--- a/dart_filament/native/lib/android/release/x86/libdracodec.a
+++ b/dart_filament/native/lib/android/release/x86/libdracodec.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78e446b4cde5bd7dcf06ca7b1b3cf46d05cfe21d52d03bbb24324b956f37fda2
-size 1669708

--- a/dart_filament/native/lib/android/release/x86/libfilabridge.a
+++ b/dart_filament/native/lib/android/release/x86/libfilabridge.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c70d0a2983662abf721843b54c9d5126e6b9a58d4ab09f3862cf0a80c4f333f3
-size 39044

--- a/dart_filament/native/lib/android/release/x86/libfilaflat.a
+++ b/dart_filament/native/lib/android/release/x86/libfilaflat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d89805f1256be54f65ab9c74da0583f9c0235226583263964307d5e94fd35e44
-size 30978

--- a/dart_filament/native/lib/android/release/x86/libfilamat.a
+++ b/dart_filament/native/lib/android/release/x86/libfilamat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d697ee595317c76a1d81fd3f8abf029ed43f687b05f5344b15a169188ed5815
-size 20289628

--- a/dart_filament/native/lib/android/release/x86/libfilament-iblprefilter.a
+++ b/dart_filament/native/lib/android/release/x86/libfilament-iblprefilter.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:95a184df6178245da98b5f4cf4d102564df2847044314c98e4a21a90586072e5
-size 57922

--- a/dart_filament/native/lib/android/release/x86/libfilament.a
+++ b/dart_filament/native/lib/android/release/x86/libfilament.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d66c35061e66a5234969c67c0dc7a088d593a5c2cc2a32111db4e9df3059d75
-size 2275644

--- a/dart_filament/native/lib/android/release/x86/libfilameshio.a
+++ b/dart_filament/native/lib/android/release/x86/libfilameshio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e1f2352a751d4b11491953594b734fd3b5eed850acdffab070bfdba7a181e671
-size 25342

--- a/dart_filament/native/lib/android/release/x86/libgeometry.a
+++ b/dart_filament/native/lib/android/release/x86/libgeometry.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82146f6482e6b5ca4f348a2965132bc6b69093e6da6a89cea8798e34f68f5dd3
-size 293224

--- a/dart_filament/native/lib/android/release/x86/libgltfio_core.a
+++ b/dart_filament/native/lib/android/release/x86/libgltfio_core.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66f53c6e998042e6a8a357564e7b7bb12eddaa74b5d1b7d6d38302e1a7599a29
-size 773392

--- a/dart_filament/native/lib/android/release/x86/libibl-lite.a
+++ b/dart_filament/native/lib/android/release/x86/libibl-lite.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f90586ee24c55b4b40b5c59c53c0a3faac422d3e218c3b807d7d838ad50763cb
-size 193288

--- a/dart_filament/native/lib/android/release/x86/libibl.a
+++ b/dart_filament/native/lib/android/release/x86/libibl.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9fdd674a4c0bce672ede950c48f929ef9fd5a5c2467d7d6146309dfd2f7988ae
-size 235302

--- a/dart_filament/native/lib/android/release/x86/libimage.a
+++ b/dart_filament/native/lib/android/release/x86/libimage.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:35913c719afa01a54506b393b48402ee75a87d80f672ebf1bc4f4119f6cd481e
-size 66658

--- a/dart_filament/native/lib/android/release/x86/libimageio.a
+++ b/dart_filament/native/lib/android/release/x86/libimageio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fad4729150c16cbc07a1ef3f442f17c539723329a74e52e50b8001ded18061e2
-size 167674

--- a/dart_filament/native/lib/android/release/x86/libktxreader.a
+++ b/dart_filament/native/lib/android/release/x86/libktxreader.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa6ce45a1982186e248dacf9e8bb9f829283633cdc8c083d36f4597c21d5d38f
-size 46006

--- a/dart_filament/native/lib/android/release/x86/libmeshoptimizer.a
+++ b/dart_filament/native/lib/android/release/x86/libmeshoptimizer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9b0ba2884fa6bf0d5a7ff55cb572a150dd828173782b3d30840314a89007307
-size 116746

--- a/dart_filament/native/lib/android/release/x86/libmikktspace.a
+++ b/dart_filament/native/lib/android/release/x86/libmikktspace.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:576a35b20d60c327aa165ad882b0370c747e305e772018897fe92e896bc4d580
-size 24674

--- a/dart_filament/native/lib/android/release/x86/libpng.a
+++ b/dart_filament/native/lib/android/release/x86/libpng.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68680810cf49495414ca6c5098b726696038bccb892f9de56c2899f97ae483c6
-size 308346

--- a/dart_filament/native/lib/android/release/x86/libshaders.a
+++ b/dart_filament/native/lib/android/release/x86/libshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa6340502a4488faac1bdec36fa18837f364a052e82aa3bb38fcfc5ea5f35cf9
-size 131170

--- a/dart_filament/native/lib/android/release/x86/libsmol-v.a
+++ b/dart_filament/native/lib/android/release/x86/libsmol-v.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1248c62aec9b7685e28b3dab4b771d362c3ab79715f7b6c0cb815177dc6af199
-size 38928

--- a/dart_filament/native/lib/android/release/x86/libstb.a
+++ b/dart_filament/native/lib/android/release/x86/libstb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f805c62af73d67ebd4e4190a6898c1c239e5140444dece032c961b87e367a882
-size 109674

--- a/dart_filament/native/lib/android/release/x86/libtinyexr.a
+++ b/dart_filament/native/lib/android/release/x86/libtinyexr.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9a1b003919d978bac2301ed573b511f80101da311cd33486290cd4ba0caf953
-size 175696

--- a/dart_filament/native/lib/android/release/x86/libuberarchive.a
+++ b/dart_filament/native/lib/android/release/x86/libuberarchive.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91d1d25c742b4b794785afb504fb3d4c70ca0d68d202f4f2d396fbcc4e3d64f7
-size 1928152

--- a/dart_filament/native/lib/android/release/x86/libuberzlib.a
+++ b/dart_filament/native/lib/android/release/x86/libuberzlib.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2d660cb15a31f28a900c2ca2f10e86561fe7004caadc56e52c9c6d3a3139351
-size 21200

--- a/dart_filament/native/lib/android/release/x86/libutils.a
+++ b/dart_filament/native/lib/android/release/x86/libutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:18c60c4fd4e07f7eb0cb92b80f11da4a7b78d5364fa0114b04318b0b4309bc39
-size 191424

--- a/dart_filament/native/lib/android/release/x86/libviewer.a
+++ b/dart_filament/native/lib/android/release/x86/libviewer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad6a81806956f0e3b5aa14f564b63a84e4a2e101b11053e326b4bab24a8d45ec
-size 383764

--- a/dart_filament/native/lib/android/release/x86/libvkshaders.a
+++ b/dart_filament/native/lib/android/release/x86/libvkshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af65b95cebee5edab0fa48f64ece19d19c6d295744c0fad9012320cdba766a10
-size 2058

--- a/dart_filament/native/lib/android/release/x86/libzstd.a
+++ b/dart_filament/native/lib/android/release/x86/libzstd.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a51e420bae846b043345f2de6da16c1d42f241f1eaa6dd30b53cb9b41fe1da46
-size 820802

--- a/dart_filament/native/lib/android/release/x86_64/libbackend.a
+++ b/dart_filament/native/lib/android/release/x86_64/libbackend.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7ad950828265e57d17ae64b5ee6429983e818be815fff8d31ecb4ff91e02a58
-size 1766820

--- a/dart_filament/native/lib/android/release/x86_64/libbasis_transcoder.a
+++ b/dart_filament/native/lib/android/release/x86_64/libbasis_transcoder.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:90127385bd8644f3f67b37c89a1f577e8b06542c0294b975137f2d85f6c013fb
-size 392376

--- a/dart_filament/native/lib/android/release/x86_64/libbluevk.a
+++ b/dart_filament/native/lib/android/release/x86_64/libbluevk.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9f84bb9bf0d40d277fef86e9116cc9c31b4205d52b802462f9c2f6aea6c1ce7
-size 174552

--- a/dart_filament/native/lib/android/release/x86_64/libcamutils.a
+++ b/dart_filament/native/lib/android/release/x86_64/libcamutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0eee4c5f774846a224093a78169e7e1a6334c0c762351cef1a0dc119e9ea6633
-size 51180

--- a/dart_filament/native/lib/android/release/x86_64/libcivetweb.a
+++ b/dart_filament/native/lib/android/release/x86_64/libcivetweb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb21abec7c0bbcac238ea32fd55f8b99d2cb945f7c4e7a86aee6119b6791f7f4
-size 287776

--- a/dart_filament/native/lib/android/release/x86_64/libdracodec.a
+++ b/dart_filament/native/lib/android/release/x86_64/libdracodec.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5dfdd36c9719db6026a70a479bb749355889d429ac827bf40909081472837eba
-size 1920606

--- a/dart_filament/native/lib/android/release/x86_64/libfilabridge.a
+++ b/dart_filament/native/lib/android/release/x86_64/libfilabridge.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68c74985218c8268a003bb355f7ed307e5513b316ef6ee8624cd9f6cfe472495
-size 47102

--- a/dart_filament/native/lib/android/release/x86_64/libfilaflat.a
+++ b/dart_filament/native/lib/android/release/x86_64/libfilaflat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:63d87db2d8293f00918601cae9fa656bee2b868348ca86fe1b75a16937845682
-size 35234

--- a/dart_filament/native/lib/android/release/x86_64/libfilamat.a
+++ b/dart_filament/native/lib/android/release/x86_64/libfilamat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49953954b6415931cbe09bac7be19b93898c7ba1e0e1b14f349fc363a5cae440
-size 25416522

--- a/dart_filament/native/lib/android/release/x86_64/libfilament-iblprefilter.a
+++ b/dart_filament/native/lib/android/release/x86_64/libfilament-iblprefilter.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32c34f63a100302b8eb615fc34d6ccdfd9b3b3d60d8eef08a570b09b344e93c2
-size 66546

--- a/dart_filament/native/lib/android/release/x86_64/libfilament.a
+++ b/dart_filament/native/lib/android/release/x86_64/libfilament.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:17de0b8f9c5040478d232ea57182c6a4b5ccea1edb92dfc367d4929f810cfe3d
-size 2501238

--- a/dart_filament/native/lib/android/release/x86_64/libfilameshio.a
+++ b/dart_filament/native/lib/android/release/x86_64/libfilameshio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7bd80488454552e7d8720da63411de6ddc037c20b6b41a45c9883189fe3cbdb
-size 29762

--- a/dart_filament/native/lib/android/release/x86_64/libgeometry.a
+++ b/dart_filament/native/lib/android/release/x86_64/libgeometry.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6072901d127b70e1166110d453cce7ac1af9ec12421171435ee455b922fd854b
-size 343980

--- a/dart_filament/native/lib/android/release/x86_64/libgltfio_core.a
+++ b/dart_filament/native/lib/android/release/x86_64/libgltfio_core.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b93d647da1202ed4641896f02777d6163563318712e78eed7b8c332723df3932
-size 903740

--- a/dart_filament/native/lib/android/release/x86_64/libibl-lite.a
+++ b/dart_filament/native/lib/android/release/x86_64/libibl-lite.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc5b9277238fa6380f969692a153289c7d4b657e62d1d280a183e4f96b9e1ebc
-size 222552

--- a/dart_filament/native/lib/android/release/x86_64/libibl.a
+++ b/dart_filament/native/lib/android/release/x86_64/libibl.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3a7087ef9fb35c517c9bf62f3e92260d6393756152f9abd992deb9a0aa46211
-size 273930

--- a/dart_filament/native/lib/android/release/x86_64/libimage.a
+++ b/dart_filament/native/lib/android/release/x86_64/libimage.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d60de9e17dfa87c8ba9f57d5097ba0b37dae4cde9b9cd345164ba97958eeb8ee
-size 78096

--- a/dart_filament/native/lib/android/release/x86_64/libimageio.a
+++ b/dart_filament/native/lib/android/release/x86_64/libimageio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d61c0a18fe03e0d62c48a6d95b346a84191dedd06f0d755c71e4967dace31ef2
-size 209914

--- a/dart_filament/native/lib/android/release/x86_64/libktxreader.a
+++ b/dart_filament/native/lib/android/release/x86_64/libktxreader.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d30372070651a8304875174545663e9b7c83bd2996dd985bf621726e393f5939
-size 73092

--- a/dart_filament/native/lib/android/release/x86_64/libmeshoptimizer.a
+++ b/dart_filament/native/lib/android/release/x86_64/libmeshoptimizer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:266996118d3c1ca760a6d2be869bc05bc45b89646bce4ab9dd4186dabca006f8
-size 136746

--- a/dart_filament/native/lib/android/release/x86_64/libmikktspace.a
+++ b/dart_filament/native/lib/android/release/x86_64/libmikktspace.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93208a5908582b251973389e49fa480b5e241af187975594dccdc77d79d321f8
-size 26822

--- a/dart_filament/native/lib/android/release/x86_64/libpng.a
+++ b/dart_filament/native/lib/android/release/x86_64/libpng.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b62be7d7eedb390e4f26940c9a65ce0fc8515c9cdab029b50b3bcbada2469f8a
-size 383722

--- a/dart_filament/native/lib/android/release/x86_64/libshaders.a
+++ b/dart_filament/native/lib/android/release/x86_64/libshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9310414fec8a771ceee59d5bd9deefe4db015ab9a569b11c08028380b557642a
-size 131990

--- a/dart_filament/native/lib/android/release/x86_64/libsmol-v.a
+++ b/dart_filament/native/lib/android/release/x86_64/libsmol-v.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:779246f9bd399d1c93690df00cd6f1f674b802fef06acfffe9970f5b112f80e3
-size 49708

--- a/dart_filament/native/lib/android/release/x86_64/libstb.a
+++ b/dart_filament/native/lib/android/release/x86_64/libstb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e51130a0c42f1ec8ad91e171c791dc25c4f3eb9c7878cd249ac5571228aa091
-size 132182

--- a/dart_filament/native/lib/android/release/x86_64/libtinyexr.a
+++ b/dart_filament/native/lib/android/release/x86_64/libtinyexr.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8dca39d876437fefd651bbc5aaecf4f11e95c9ad8b2d7f3b4d1116976673ecac
-size 220104

--- a/dart_filament/native/lib/android/release/x86_64/libuberarchive.a
+++ b/dart_filament/native/lib/android/release/x86_64/libuberarchive.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c815de277192abfa1a2cd5bf630b1b60584542f4bbd2f15a464cca996210cb54
-size 1928492

--- a/dart_filament/native/lib/android/release/x86_64/libuberzlib.a
+++ b/dart_filament/native/lib/android/release/x86_64/libuberzlib.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8a72381c18099a6c3e6f4fc0f2e7dd17136c60ccb5064368efa495d5a0da087
-size 22928

--- a/dart_filament/native/lib/android/release/x86_64/libutils.a
+++ b/dart_filament/native/lib/android/release/x86_64/libutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec3dc4bbc07bdaa7a2e3e37590cc428eec9253fef42be6a09e6e1fe4e1cb2139
-size 232672

--- a/dart_filament/native/lib/android/release/x86_64/libviewer.a
+++ b/dart_filament/native/lib/android/release/x86_64/libviewer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:737439070780b6740c81a71003fdb6568e75b9dc31ddfd7aea07eeae7be0a7e3
-size 510184

--- a/dart_filament/native/lib/android/release/x86_64/libvkshaders.a
+++ b/dart_filament/native/lib/android/release/x86_64/libvkshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f273ddf903b840d7f3f202b8f6a6f9d530d77dbb217e3688dbddde4538d00a2d
-size 2422

--- a/dart_filament/native/lib/android/release/x86_64/libzstd.a
+++ b/dart_filament/native/lib/android/release/x86_64/libzstd.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3bc9106f0f1bd74a777ebec402c8217a7a043e2bac13591548bb69bbefc36395
-size 817266

--- a/dart_filament/native/lib/ios/libbackend.a
+++ b/dart_filament/native/lib/ios/libbackend.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78b799b769ddf2e3cfe091f81a2a1b7252c9c974b0d8839b2de02eac8ca98e88
-size 3039272

--- a/dart_filament/native/lib/ios/libbasis_transcoder.a
+++ b/dart_filament/native/lib/ios/libbasis_transcoder.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b23944a06b713b016c679d0b257d21b5afdc940cfd60bcc3f23f32df14d6c6f
-size 908192

--- a/dart_filament/native/lib/ios/libcamutils.a
+++ b/dart_filament/native/lib/ios/libcamutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f4f9540df738e6519183de4fc91a89e37e36f0124c58c40c62f237771c73d96
-size 79976

--- a/dart_filament/native/lib/ios/libcivetweb.a
+++ b/dart_filament/native/lib/ios/libcivetweb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1700aa159e33a3de9f31f0178f1006530dafc31d1ca711ee9999ebce350602b1
-size 601384

--- a/dart_filament/native/lib/ios/libdracodec.a
+++ b/dart_filament/native/lib/ios/libdracodec.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:407e8e491ab34435cd018f437929d8c54021c878361c2002ed9f1d367298e853
-size 4018752

--- a/dart_filament/native/lib/ios/libfilabridge.a
+++ b/dart_filament/native/lib/ios/libfilabridge.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40260ca0fac600a62a3a7ce9eabee1258f45fbfbf272a056cd46b2fce12a7985
-size 117128

--- a/dart_filament/native/lib/ios/libfilaflat.a
+++ b/dart_filament/native/lib/ios/libfilaflat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1df8c219c22ad8c659ec2d0787648c7d472ea416e3fc8fb9f4ef714e84940c96
-size 96640

--- a/dart_filament/native/lib/ios/libfilamat.a
+++ b/dart_filament/native/lib/ios/libfilamat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33c75aeeb3ef433a0a0140ef26512e179bb93e28cc5887c72f886ebfefae26db
-size 57101640

--- a/dart_filament/native/lib/ios/libfilamat_lite.a
+++ b/dart_filament/native/lib/ios/libfilamat_lite.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:356aae22b114291555cb977c43d0147c7accb6293425511f5bde48f56b43abe9
-size 11035352

--- a/dart_filament/native/lib/ios/libfilament-iblprefilter.a
+++ b/dart_filament/native/lib/ios/libfilament-iblprefilter.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc61b274ffa6b3bb646b2c748ac8e9de33a98d42a2044251239d0c63f380e46f
-size 115024

--- a/dart_filament/native/lib/ios/libfilament.a
+++ b/dart_filament/native/lib/ios/libfilament.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccc2728bc13bb60bc29956dd6e07a8eb001b9e9356a65d30e0d2411b41e83ad7
-size 6935240

--- a/dart_filament/native/lib/ios/libfilameshio.a
+++ b/dart_filament/native/lib/ios/libfilameshio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db9aefa83befc70c42d072a00685eaa3a9cc668d88681bb8ceef2639763334c9
-size 71872

--- a/dart_filament/native/lib/ios/libgeometry.a
+++ b/dart_filament/native/lib/ios/libgeometry.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:665b1319ea4f950041e1e3a60481484480125c2912e8ba419bc365d881eea766
-size 729808

--- a/dart_filament/native/lib/ios/libgltfio_core.a
+++ b/dart_filament/native/lib/ios/libgltfio_core.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e3bb1c527902c1511ca85add0164ba0f4562f722050a2719037f66922f779f8c
-size 2269744

--- a/dart_filament/native/lib/ios/libibl-lite.a
+++ b/dart_filament/native/lib/ios/libibl-lite.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3aaa0a940653d6d0aa6bb57be3866502c98dcbdc6a9d8bfe8649af23945fa98e
-size 451048

--- a/dart_filament/native/lib/ios/libibl.a
+++ b/dart_filament/native/lib/ios/libibl.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6bf69b474dce2fd80c91b751cf14e1cc7455c06b3ded3645f7f77d63c465fdda
-size 538416

--- a/dart_filament/native/lib/ios/libimage.a
+++ b/dart_filament/native/lib/ios/libimage.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e43c34d2cfc861a113b446b787d6943675d5ebe4c016ddf5fec762d28dc1fafd
-size 173168

--- a/dart_filament/native/lib/ios/libimageio.a
+++ b/dart_filament/native/lib/ios/libimageio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad2e5aa84406de17330971fa2272a954cfde32faa5962c4cbdbad0cdcfade6b7
-size 378456

--- a/dart_filament/native/lib/ios/libktxreader.a
+++ b/dart_filament/native/lib/ios/libktxreader.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13c2bae69a7d4ebd537239afcec80dd9ae03392c071a480899c842b7a152591a
-size 92728

--- a/dart_filament/native/lib/ios/libmeshoptimizer.a
+++ b/dart_filament/native/lib/ios/libmeshoptimizer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1460a7800b6edcc5aad6bfeb0217bdeffafd5e311d660cfcb5f44615b91bc5ea
-size 264032

--- a/dart_filament/native/lib/ios/libmikktspace.a
+++ b/dart_filament/native/lib/ios/libmikktspace.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f62cd9cebff804e583760b52790a6f25d066d97b0227ececa99ec75c6006aed6
-size 58584

--- a/dart_filament/native/lib/ios/libpng.a
+++ b/dart_filament/native/lib/ios/libpng.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f40a337ca4ae110bbfee332e03ee496b0f3706b6b9d264a44f3c248733f4f23
-size 376488

--- a/dart_filament/native/lib/ios/libpng16.a
+++ b/dart_filament/native/lib/ios/libpng16.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f40a337ca4ae110bbfee332e03ee496b0f3706b6b9d264a44f3c248733f4f23
-size 376488

--- a/dart_filament/native/lib/ios/libshaders.a
+++ b/dart_filament/native/lib/ios/libshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d5948a353cdc744858e7bddada1fff26d7fd044ce23995919f2d318e2968ec2a
-size 131976

--- a/dart_filament/native/lib/ios/libsmol-v.a
+++ b/dart_filament/native/lib/ios/libsmol-v.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68e0c949246bf9cc0376620f6d77a8aa08ba719bebae10eb7e5623b858a9c340
-size 101496

--- a/dart_filament/native/lib/ios/libstb.a
+++ b/dart_filament/native/lib/ios/libstb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4d7e1721e519ec8476839afbefd73b8f1dfd512a1facae367804df76f428784
-size 264272

--- a/dart_filament/native/lib/ios/libtinyexr.a
+++ b/dart_filament/native/lib/ios/libtinyexr.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60e5e22f31b84e116475a8232310b3a452134587e81a2d0f9bf5c1a0af834f06
-size 511480

--- a/dart_filament/native/lib/ios/libuberarchive.a
+++ b/dart_filament/native/lib/ios/libuberarchive.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:54a02890e4dde79e4e06b63c2af255265230e1a271aa06af67859bab63001521
-size 1718944

--- a/dart_filament/native/lib/ios/libuberzlib.a
+++ b/dart_filament/native/lib/ios/libuberzlib.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebedb74ed4dafe239dce7993c498a6f510d0579ec89b52aa06514c4519e0402a
-size 65448

--- a/dart_filament/native/lib/ios/libutils.a
+++ b/dart_filament/native/lib/ios/libutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0344b0d67c770869008ad7fdf80cc27113647749cc66a18cad7b745bd105d472
-size 493240

--- a/dart_filament/native/lib/ios/libviewer.a
+++ b/dart_filament/native/lib/ios/libviewer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6658b3b014a47f4060d47df98f05383a1b9a77c875c53057214c070461ece24
-size 927992

--- a/dart_filament/native/lib/ios/libvkshaders.a
+++ b/dart_filament/native/lib/ios/libvkshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4af7e94f5308d398db24bb3899bc67ca25a30e72d23553911cddbe2120c24ac
-size 4616

--- a/dart_filament/native/lib/ios/libzstd.a
+++ b/dart_filament/native/lib/ios/libzstd.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:021fd59f3cee4f783caeaea2714afef241574c01d010bea889756ea15622056a
-size 1707168

--- a/dart_filament/native/lib/macos/debug/libbackend.a
+++ b/dart_filament/native/lib/macos/debug/libbackend.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:affab4b1bd22a9bc435372e447012d155e5e0fcbc59b989aff59c8e0361cfcbf
-size 62274672

--- a/dart_filament/native/lib/macos/debug/libbasis_transcoder.a
+++ b/dart_filament/native/lib/macos/debug/libbasis_transcoder.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a89d1ea540fe86de50be51e1931fd0d4618165c24ba8580e9c338b647cb28331
-size 1086520

--- a/dart_filament/native/lib/macos/debug/libbluegl.a
+++ b/dart_filament/native/lib/macos/debug/libbluegl.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bce716fc18a0fbf5a19e01095df30118ea738921705dc35568cd976d47fac9f8
-size 1475432

--- a/dart_filament/native/lib/macos/debug/libbluevk.a
+++ b/dart_filament/native/lib/macos/debug/libbluevk.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd8cc2ea25fb3d9f1651c8f354cf13b0c38678e5d996ca91417ac9ebdc148c04
-size 724648

--- a/dart_filament/native/lib/macos/debug/libcamutils.a
+++ b/dart_filament/native/lib/macos/debug/libcamutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2241a94e0752c34129d787714549df2218ab719ac9170af6888844dac79b8d66
-size 215256

--- a/dart_filament/native/lib/macos/debug/libcivetweb.a
+++ b/dart_filament/native/lib/macos/debug/libcivetweb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d54f296db961edd8db33dd7eea2d2da89dd09ef0d7e1c26fd053d154e3562e6
-size 995640

--- a/dart_filament/native/lib/macos/debug/libdracodec.a
+++ b/dart_filament/native/lib/macos/debug/libdracodec.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e193bb074b413e104864cdb87d79539c0b7a795cb92172b2df2a5183dcf6344
-size 51077024

--- a/dart_filament/native/lib/macos/debug/libfilabridge.a
+++ b/dart_filament/native/lib/macos/debug/libfilabridge.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a614f038baa9bf0b595a0933cf981eb91ff12984d272d5de7ad294c79b18961d
-size 1119608

--- a/dart_filament/native/lib/macos/debug/libfilaflat.a
+++ b/dart_filament/native/lib/macos/debug/libfilaflat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:67cc917ada588b84922bf8446182d62e4f4422eb5d09452ad96050a06a404f59
-size 1191240

--- a/dart_filament/native/lib/macos/debug/libfilamat.a
+++ b/dart_filament/native/lib/macos/debug/libfilamat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bbcfe80f8dbe4a80492df337e2707d36f5be91f55e9e11852911675e8c6b74cc
-size 898215696

--- a/dart_filament/native/lib/macos/debug/libfilament-iblprefilter.a
+++ b/dart_filament/native/lib/macos/debug/libfilament-iblprefilter.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:693a251f3016de1ad712d90b171fe7da709ccfca94583478dbef24beef98c65a
-size 331424

--- a/dart_filament/native/lib/macos/debug/libfilament.a
+++ b/dart_filament/native/lib/macos/debug/libfilament.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50388d73714e7952b8a7933ba08569fa10bd06324983cdfa13083286a8ef820f
-size 137389784

--- a/dart_filament/native/lib/macos/debug/libfilameshio.a
+++ b/dart_filament/native/lib/macos/debug/libfilameshio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea9208539ee1d47b7697a0edaa126abc68533e9f772159f7484cb36f98ee0889
-size 509280

--- a/dart_filament/native/lib/macos/debug/libgeometry.a
+++ b/dart_filament/native/lib/macos/debug/libgeometry.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8031bad87a140180994512f289fdf2b5661de4b89a2da8cd840c1e9c45e25338
-size 5759112

--- a/dart_filament/native/lib/macos/debug/libgltfio.a
+++ b/dart_filament/native/lib/macos/debug/libgltfio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cde181927fd543a083f5e55f357dd436bede57e57dd18593d9b54e59c44ae7af
-size 684696

--- a/dart_filament/native/lib/macos/debug/libgltfio_core.a
+++ b/dart_filament/native/lib/macos/debug/libgltfio_core.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b27070d086d5407eef3fe25ffe056777f19b7554aa7bdb6a142d169514f6b7a8
-size 28838864

--- a/dart_filament/native/lib/macos/debug/libibl-lite.a
+++ b/dart_filament/native/lib/macos/debug/libibl-lite.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d4acf706d1379ec51fc589846a3f7a3a11693108591d815e0463131cc1a95bac
-size 4985040

--- a/dart_filament/native/lib/macos/debug/libibl.a
+++ b/dart_filament/native/lib/macos/debug/libibl.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d86bed29758669a6597285cefc5dd2d77018fd45b42356da4e5a54455314101
-size 5991632

--- a/dart_filament/native/lib/macos/debug/libimage.a
+++ b/dart_filament/native/lib/macos/debug/libimage.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:69354f18bdcfeaa55364325b6203efea07eacef56e1c6920caf06cac3ae190ca
-size 1267944

--- a/dart_filament/native/lib/macos/debug/libimageio.a
+++ b/dart_filament/native/lib/macos/debug/libimageio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9e127b2cf73ac440a80136b4e4122b322b4389a4096cd4935aba699d5d53bf2
-size 253968

--- a/dart_filament/native/lib/macos/debug/libktxreader.a
+++ b/dart_filament/native/lib/macos/debug/libktxreader.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6de345a4d55c193ddb99025ec0df114be851169706ef5dd1e701ae56e1182f4e
-size 520032

--- a/dart_filament/native/lib/macos/debug/libmatdbg.a
+++ b/dart_filament/native/lib/macos/debug/libmatdbg.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:720af6233c377ea4456f30ef04b2013628f6ffda8a20f3f46fc639befed3b3e3
-size 154906448

--- a/dart_filament/native/lib/macos/debug/libmeshoptimizer.a
+++ b/dart_filament/native/lib/macos/debug/libmeshoptimizer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aeb6ec2eedd1e66502871bfdbab026201b9c549500b1b625c2c5dcf09a447fec
-size 452304

--- a/dart_filament/native/lib/macos/debug/libmikktspace.a
+++ b/dart_filament/native/lib/macos/debug/libmikktspace.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:51c18d35ea7de0960a62a0b69c87ddc97c7baf1ed0b3dc0b5e926b0b1ec63f73
-size 80984

--- a/dart_filament/native/lib/macos/debug/libpng.a
+++ b/dart_filament/native/lib/macos/debug/libpng.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a9f9670d0e7a745d717e25c567440bbede44e45d86694957a072a7285d53b86
-size 612144

--- a/dart_filament/native/lib/macos/debug/libshaders.a
+++ b/dart_filament/native/lib/macos/debug/libshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:289f944f5883ef2f4056b8699a18cfc0c96cfb875c7e1aa613ebea6d3f4e5674
-size 211304

--- a/dart_filament/native/lib/macos/debug/libsmol-v.a
+++ b/dart_filament/native/lib/macos/debug/libsmol-v.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dee4089f988747ab854497b3a2974d7f8682598d72be870e0e53b25bc72b861d
-size 279432

--- a/dart_filament/native/lib/macos/debug/libstb.a
+++ b/dart_filament/native/lib/macos/debug/libstb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a76e82a20b7d25214665d2aa23f5698845888e1f2d4c7d43c16b36b29a9ce0e7
-size 199344

--- a/dart_filament/native/lib/macos/debug/libtinyexr.a
+++ b/dart_filament/native/lib/macos/debug/libtinyexr.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34ad29c149c864f29c177321c08552bac39e39c20fb6395191221d3aacddaa08
-size 290424

--- a/dart_filament/native/lib/macos/debug/libuberarchive.a
+++ b/dart_filament/native/lib/macos/debug/libuberarchive.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b3d66ff4e08f1c78da18d32b6130774c10eb113e2fdf799bf2b076fa7e12a5a
-size 17940312

--- a/dart_filament/native/lib/macos/debug/libuberzlib.a
+++ b/dart_filament/native/lib/macos/debug/libuberzlib.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe12e83718e1cf59373e51133f18e89024c71595fc5481be9102dac17d733408
-size 592472

--- a/dart_filament/native/lib/macos/debug/libutils.a
+++ b/dart_filament/native/lib/macos/debug/libutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e20f5b9d2016f5b6496530ed3ff3434b6b58657aa3934ed39ce94cb295b1397a
-size 3528280

--- a/dart_filament/native/lib/macos/debug/libviewer.a
+++ b/dart_filament/native/lib/macos/debug/libviewer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d1570bb299aacdda039300a7c8b57ca175181181e3b11ca162af428a334640e
-size 3670528

--- a/dart_filament/native/lib/macos/debug/libvkshaders.a
+++ b/dart_filament/native/lib/macos/debug/libvkshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47644331da2c1f9d0fe2d4354f6b0d0716edf4696663818df34f8d8f32016f49
-size 2760

--- a/dart_filament/native/lib/macos/debug/libzstd.a
+++ b/dart_filament/native/lib/macos/debug/libzstd.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d33de6b43c649371061eb26461584c53a4ef1b5b4c162218b6d12d5f75fcb7c4
-size 2376512

--- a/dart_filament/native/lib/macos/release/libbackend.a
+++ b/dart_filament/native/lib/macos/release/libbackend.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd68c14b2f7455f25c1d9d008c224d4fa108ac2ddb6f722555795159c682ab5b
-size 2226432

--- a/dart_filament/native/lib/macos/release/libbasis_transcoder.a
+++ b/dart_filament/native/lib/macos/release/libbasis_transcoder.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de2d73b815146c9f98edf694aed4f6e80d5d02ea653566b503c328d11c66aca6
-size 477072

--- a/dart_filament/native/lib/macos/release/libbluegl.a
+++ b/dart_filament/native/lib/macos/release/libbluegl.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0abb716203b2de32c559c4d186b3625650a9afc51f7724bf5265debceba9d1e
-size 905576

--- a/dart_filament/native/lib/macos/release/libbluevk.a
+++ b/dart_filament/native/lib/macos/release/libbluevk.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:006810d34173a75d857eaf7cee4c09c087da200e2ad14eca87a1ef33908bf3f9
-size 122640

--- a/dart_filament/native/lib/macos/release/libcamutils.a
+++ b/dart_filament/native/lib/macos/release/libcamutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7c0a7da26327ffc1ea4651c1918a6455e7325659c6a403da36d027886f2defe
-size 33152

--- a/dart_filament/native/lib/macos/release/libcivetweb.a
+++ b/dart_filament/native/lib/macos/release/libcivetweb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a70f838f2e34a0aaaa3234ec0c01865aef6a7a58e9f2c242465c086aaea13d4a
-size 251856

--- a/dart_filament/native/lib/macos/release/libdracodec.a
+++ b/dart_filament/native/lib/macos/release/libdracodec.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e7c70d8096f42df4bbd38b9af077a63f998470a019d93f4a64141a4c610170
-size 1808248

--- a/dart_filament/native/lib/macos/release/libfilabridge.a
+++ b/dart_filament/native/lib/macos/release/libfilabridge.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6639997cd9d2dbfe047157304250911ffd44cafb9bcd35febfa1853b6ae4c6d4
-size 43736

--- a/dart_filament/native/lib/macos/release/libfilaflat.a
+++ b/dart_filament/native/lib/macos/release/libfilaflat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e416604b0fa4cb6aa5f195de7bbc3d6a3529a03fe3164e34ccc3707538c3e990
-size 34480

--- a/dart_filament/native/lib/macos/release/libfilagui.a
+++ b/dart_filament/native/lib/macos/release/libfilagui.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3489e9fda68af9a5401b134660288fbf6f40b6ed4bdcdca7ad57f619df4e1685
-size 239408

--- a/dart_filament/native/lib/macos/release/libfilamat.a
+++ b/dart_filament/native/lib/macos/release/libfilamat.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c95b8f400a667de15c2717f09b24d69c1e3aab895865ba6ce5d408f1f8573a3e
-size 20503712

--- a/dart_filament/native/lib/macos/release/libfilamat_combined.a
+++ b/dart_filament/native/lib/macos/release/libfilamat_combined.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32b5db3f25f6ae708a9df7e5b1b8eb1df80df1e4719ab59336c375c5015e28ae
-size 39527640

--- a/dart_filament/native/lib/macos/release/libfilamat_lite.a
+++ b/dart_filament/native/lib/macos/release/libfilamat_lite.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c5159dbdbe33a2cbd3657a750f6526c97f5c6070df31c6eb14bf0dc80672bbb2
-size 892408

--- a/dart_filament/native/lib/macos/release/libfilament-iblprefilter.a
+++ b/dart_filament/native/lib/macos/release/libfilament-iblprefilter.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7192db2ecd163c4f18fe1a6f60627ba7ffd7e4602b73bdef7fbbe24c82c537b
-size 74544

--- a/dart_filament/native/lib/macos/release/libfilament.a
+++ b/dart_filament/native/lib/macos/release/libfilament.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:95106e2e136e5640d99375cdf5ebe941ecdf8ab5a9442b3b574af874f4359e4b
-size 2659400

--- a/dart_filament/native/lib/macos/release/libfilameshio.a
+++ b/dart_filament/native/lib/macos/release/libfilameshio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f47e7ceb0ddaac99ef3918456aa5a408394a3034d4d1548227c08f015e58b19f
-size 29664

--- a/dart_filament/native/lib/macos/release/libgeometry.a
+++ b/dart_filament/native/lib/macos/release/libgeometry.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0c257f69885620f3f82db3dfb5ddff132b7d7faa91c60149d9b6c7e301a4573
-size 277440

--- a/dart_filament/native/lib/macos/release/libgeometry_combined.a
+++ b/dart_filament/native/lib/macos/release/libgeometry_combined.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2ae9e4155fb6b007c0b4607ad3bbf95f0b7b5ec2b624dad69202a6f28f4d22c
-size 153144

--- a/dart_filament/native/lib/macos/release/libgltfio.a
+++ b/dart_filament/native/lib/macos/release/libgltfio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f4951ecb30c465f9930fd5ab6a3b5dc5da87c40c4f898ecd86ae2a7972d7fde
-size 35216

--- a/dart_filament/native/lib/macos/release/libgltfio_core.a
+++ b/dart_filament/native/lib/macos/release/libgltfio_core.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fbdd76a1d208cec2c1166f30b80c4101ca1e8ba224a33ea58dcb895162497cc
-size 892736

--- a/dart_filament/native/lib/macos/release/libibl-lite.a
+++ b/dart_filament/native/lib/macos/release/libibl-lite.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7eb9fef912787e2541497c13de82d75bf05dd51175a8476c5501a2c2316d6cb
-size 257880

--- a/dart_filament/native/lib/macos/release/libibl.a
+++ b/dart_filament/native/lib/macos/release/libibl.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2422656760e67a9c880cb8cb7f45e4eeca5e7eb8626c4bae00372a64af8ea5e3
-size 316416

--- a/dart_filament/native/lib/macos/release/libimage.a
+++ b/dart_filament/native/lib/macos/release/libimage.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9884d0c996355ae00857df02e9ed3ee8fccd3090c0d911849797f8d6bb56f15f
-size 72400

--- a/dart_filament/native/lib/macos/release/libimageio.a
+++ b/dart_filament/native/lib/macos/release/libimageio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9e127b2cf73ac440a80136b4e4122b322b4389a4096cd4935aba699d5d53bf2
-size 253968

--- a/dart_filament/native/lib/macos/release/libktxreader.a
+++ b/dart_filament/native/lib/macos/release/libktxreader.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a6ced6b6f84d345380e37f086ae3c98918b0e54cd27030774c42a553501c07a6
-size 36184

--- a/dart_filament/native/lib/macos/release/libmatdbg.a
+++ b/dart_filament/native/lib/macos/release/libmatdbg.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:38fdcd69cd1ce7dd9bba85e4ed5e6a146f8b3f9e4b8c300f77c98b1917666599
-size 5897064

--- a/dart_filament/native/lib/macos/release/libmatdbg_combined.a
+++ b/dart_filament/native/lib/macos/release/libmatdbg_combined.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14c2fb432233dc9892807f27f90651eb8d7f7a7483c20354e5494a15c022e0ea
-size 10639272

--- a/dart_filament/native/lib/macos/release/libmatdbg_resources.a
+++ b/dart_filament/native/lib/macos/release/libmatdbg_resources.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0cfb5a4b14f4cf7331756038af1100117c9ec9d2e19160cb7a681c26fbf37b0
-size 46968

--- a/dart_filament/native/lib/macos/release/libmath.a
+++ b/dart_filament/native/lib/macos/release/libmath.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f72d56b122b391c7f3502184d476b4ce27f0b4a8275713d9c224821c9b10c0b1
-size 944

--- a/dart_filament/native/lib/macos/release/libmathio.a
+++ b/dart_filament/native/lib/macos/release/libmathio.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bafc1948b89206f781ea809f04c922e161d28875dcc8952d9d8466ca5b971748
-size 66904

--- a/dart_filament/native/lib/macos/release/libmeshoptimizer.a
+++ b/dart_filament/native/lib/macos/release/libmeshoptimizer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd97c592e8e3b6078d02651b74627aaee60e7dca9d84e5547745d52946f51bff
-size 103224

--- a/dart_filament/native/lib/macos/release/libmikktspace.a
+++ b/dart_filament/native/lib/macos/release/libmikktspace.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0a4cc1bb58582fc44beb01db172192fbfa0646ac35fd9f2f6cd2466d23c3efe
-size 18664

--- a/dart_filament/native/lib/macos/release/libpng.a
+++ b/dart_filament/native/lib/macos/release/libpng.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a9f9670d0e7a745d717e25c567440bbede44e45d86694957a072a7285d53b86
-size 612144

--- a/dart_filament/native/lib/macos/release/libshaders.a
+++ b/dart_filament/native/lib/macos/release/libshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1fe287758f1f821d5f01e2854f27477f022438c814d0ad0754ef62748b827047
-size 131872

--- a/dart_filament/native/lib/macos/release/libsmol-v.a
+++ b/dart_filament/native/lib/macos/release/libsmol-v.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cd4481dd5cec42ce7ad5aee26582ec9645ebffa3c303db4edd16ae4ddcbe870
-size 40968

--- a/dart_filament/native/lib/macos/release/libstb.a
+++ b/dart_filament/native/lib/macos/release/libstb.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abf16b5d9a7c45b437d2c71f825d1c5c47b78d83e5aefcb360f24e4e8faf9b4d
-size 104064

--- a/dart_filament/native/lib/macos/release/libtinyexr.a
+++ b/dart_filament/native/lib/macos/release/libtinyexr.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34ad29c149c864f29c177321c08552bac39e39c20fb6395191221d3aacddaa08
-size 290424

--- a/dart_filament/native/lib/macos/release/libuberarchive.a
+++ b/dart_filament/native/lib/macos/release/libuberarchive.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70e2ee5245c7589a8e3b873ed3bc094e5981525aa24db4064366a472ea330c94
-size 2743896

--- a/dart_filament/native/lib/macos/release/libuberzlib.a
+++ b/dart_filament/native/lib/macos/release/libuberzlib.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99d7959db42b2fe22c2b6ef5d5d8c0c02b8851cbe7fb608609ff00366108980c
-size 24080

--- a/dart_filament/native/lib/macos/release/libutils.a
+++ b/dart_filament/native/lib/macos/release/libutils.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a2c55bc9cfa89536b7a9ac2845cedeb45365904aeaa6acbce7e0007bb64245ab
-size 214032

--- a/dart_filament/native/lib/macos/release/libviewer.a
+++ b/dart_filament/native/lib/macos/release/libviewer.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7efe71a08732fcbbd971c5d850386dd167c0d126ac62d2033057383c540bffe
-size 405208

--- a/dart_filament/native/lib/macos/release/libvkshaders.a
+++ b/dart_filament/native/lib/macos/release/libvkshaders.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b32ae8a12d58c9168cd211d9be7ace650cb43734a1dd5e5d27b29f0569d63430
-size 2072

--- a/dart_filament/native/lib/macos/release/libzstd.a
+++ b/dart_filament/native/lib/macos/release/libzstd.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e02f18e6c2b09b6050ef02afb23c02918b3280290bc6e4f546633a4efd43bd3
-size 657720

--- a/dart_filament/native/lib/macos/swift/DartFilamentTexture.h
+++ b/dart_filament/native/lib/macos/swift/DartFilamentTexture.h
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4790bb825028b32518033123c2ad745917787e96c5e2083bdade1557a1d7419c
-size 10115

--- a/dart_filament/native/lib/macos/swift/build.sh
+++ b/dart_filament/native/lib/macos/swift/build.sh
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a68286e2f907b242d96268cd98b6182b66f3641a04f1567c53255354ddd04a41
-size 211

--- a/dart_filament/native/lib/macos/swift/libdartfilamenttexture.dylib
+++ b/dart_filament/native/lib/macos/swift/libdartfilamenttexture.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b607499a204000d3f4ec9a029d6e8416ce81557dc95dbceb0850af6ba482776
-size 109065

--- a/dart_filament/pubspec.yaml
+++ b/dart_filament/pubspec.yaml
@@ -12,11 +12,12 @@ dependencies:
   tuple:
   ffi:
   animation_tools_dart: ^0.0.4
+  archive: ^3.6.1
+  native_assets_cli: ^0.5.0
+  native_toolchain_c: ^0.4.0
 
 dev_dependencies:
   ffigen: ^11.0.0
-  native_assets_cli: ^0.5.0
-  native_toolchain_c: ^0.4.0
   test:
 
 


### PR DESCRIPTION
This pull request addresses #19 by adding a `_downloadLibraries` to `hooks/build.dart`.

The function downloads the native libraries for the target platform to `.dart_tool/dart_filament/native/lib` as per the [official guidelines](https://dart.dev/tools/pub/package-layout#project-specific-caching-for-tools).

If the output folder for the libraries already exists (e.g. `.dart_tool/dart_filament/native/lib/android`) it is assumed that all library files are present.
This might not be the case if a user has removed files manually, or if more libraries are added in the future. If we want to avoid those kind of issues, each file would have to be checked instead. I don't believe that that is something worth doing, however.